### PR TITLE
MX-166: Introduce multi-bureau connector abstraction with Strategy pattern

### DIFF
--- a/src/main/java/org/mifos/creditbureau/api/CreditReportApiResource.java
+++ b/src/main/java/org/mifos/creditbureau/api/CreditReportApiResource.java
@@ -1,0 +1,96 @@
+package org.mifos.creditbureau.api;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.mifos.creditbureau.data.ClientData;
+import org.mifos.creditbureau.data.ConnectionTestResult;
+import org.mifos.creditbureau.data.CreditReportResult;
+import org.mifos.creditbureau.service.ClientApiService;
+import org.mifos.creditbureau.service.connectors.ConnectorRegistry;
+import org.mifos.creditbureau.service.connectors.CreditBureauConnector;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+/**
+ * Bureau-agnostic credit report endpoint.
+ * <p>
+ * Uses the {@link ConnectorRegistry} to resolve the correct
+ * {@link CreditBureauConnector} at runtime based on the credit bureau's
+ * registered type. Supports any bureau with a registered connector —
+ * no code changes needed to add new bureaus.
+ * <p>
+ * Security: Inherits Spring Security basic auth enforcement via
+ * {@code SecurityConfig} (all {@code /api/**} paths require authentication).
+ */
+@Path("/credit-reports")
+@Component
+@Produces(MediaType.APPLICATION_JSON)
+public class CreditReportApiResource {
+
+    private final ConnectorRegistry connectorRegistry;
+    private final ClientApiService clientApiService;
+
+    @Autowired
+    public CreditReportApiResource(ConnectorRegistry connectorRegistry,
+                                   ClientApiService clientApiService) {
+        this.connectorRegistry = connectorRegistry;
+        this.clientApiService = clientApiService;
+    }
+
+    /**
+     * Fetch a credit report for a client from a specific credit bureau.
+     * The correct connector is resolved automatically based on the bureau type.
+     *
+     * @param creditBureauId the registered credit bureau ID
+     * @param clientId       the Fineract client ID
+     * @return the generalized credit report result
+     */
+    @POST
+    @Path("/{creditBureauId}/client/{clientId}")
+    public Response fetchCreditReport(
+            @PathParam("creditBureauId") Long creditBureauId,
+            @PathParam("clientId") Long clientId) {
+
+        ClientData clientData = clientApiService.getClientData(clientId);
+        CreditBureauConnector connector = connectorRegistry.getConnector(creditBureauId);
+        CreditReportResult result = connector.fetchCreditReport(creditBureauId, clientData);
+
+        return Response.ok(result).build();
+    }
+
+    /**
+     * Test connectivity with a registered credit bureau.
+     *
+     * @param creditBureauId the registered credit bureau ID
+     * @return the connection test result
+     */
+    @POST
+    @Path("/{creditBureauId}/test-connection")
+    public Response testConnection(
+            @PathParam("creditBureauId") Long creditBureauId) {
+
+        CreditBureauConnector connector = connectorRegistry.getConnector(creditBureauId);
+        ConnectionTestResult result = connector.testConnection(creditBureauId);
+
+        return Response.ok(result).build();
+    }
+
+    /**
+     * List all bureau types that have a registered connector.
+     *
+     * @return set of supported bureau type keys
+     */
+    @GET
+    @Path("/supported-bureaus")
+    public Response getSupportedBureaus() {
+        Set<String> types = connectorRegistry.getSupportedTypes();
+        return Response.ok(types).build();
+    }
+}

--- a/src/main/java/org/mifos/creditbureau/data/ConnectionTestResult.java
+++ b/src/main/java/org/mifos/creditbureau/data/ConnectionTestResult.java
@@ -1,0 +1,24 @@
+package org.mifos.creditbureau.data;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Result of a connectivity test with an external credit bureau.
+ */
+@Builder
+@Getter
+public class ConnectionTestResult {
+
+    /** Whether the connection test succeeded. */
+    private final boolean success;
+
+    /** The bureau type tested (e.g., "CIRCULO_DE_CREDITO"). */
+    private final String bureauType;
+
+    /** Human-readable message or response body from the bureau. */
+    private final String message;
+
+    /** HTTP status code returned by the bureau (0 if connection failed). */
+    private final int httpStatusCode;
+}

--- a/src/main/java/org/mifos/creditbureau/data/CreditReportResult.java
+++ b/src/main/java/org/mifos/creditbureau/data/CreditReportResult.java
@@ -1,0 +1,30 @@
+package org.mifos.creditbureau.data;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+/**
+ * Wrapper around {@link CBCreditReportData} that includes metadata
+ * about the credit report fetch operation.
+ */
+@Builder
+@Getter
+public class CreditReportResult {
+
+    /** Whether the credit report was fetched successfully. */
+    private final boolean success;
+
+    /** The generalized credit report data. */
+    private final CBCreditReportData report;
+
+    /** The bureau type that produced this report (e.g., "CIRCULO_DE_CREDITO"). */
+    private final String bureauType;
+
+    /** The raw response body from the external bureau (for auditing/debugging). */
+    private final String rawResponse;
+
+    /** Timestamp when the report was fetched. */
+    private final Instant fetchedAt;
+}

--- a/src/main/java/org/mifos/creditbureau/data/registration/CreditBureauData.java
+++ b/src/main/java/org/mifos/creditbureau/data/registration/CreditBureauData.java
@@ -22,6 +22,8 @@ public class CreditBureauData {
 
     private final String country;
 
+    private final String bureauType;
+
     private final Set<String> registrationParamKeys;
 
 

--- a/src/main/java/org/mifos/creditbureau/domain/CreditBureau.java
+++ b/src/main/java/org/mifos/creditbureau/domain/CreditBureau.java
@@ -36,6 +36,9 @@ public class CreditBureau {
     @Column(name = "country")
     private String country;
 
+    @Column(name = "bureau_type", nullable = false)
+    private String bureauType;
+
     @OneToOne(mappedBy = "creditBureau", cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonManagedReference
     private CBRegisterParams creditBureauParameter;

--- a/src/main/java/org/mifos/creditbureau/mappers/CreditBureauMapper.java
+++ b/src/main/java/org/mifos/creditbureau/mappers/CreditBureauMapper.java
@@ -32,6 +32,7 @@ public class CreditBureauMapper {
                 .creditBureauName(creditBureau.getCreditBureauName())
                 .active(creditBureau.isActive())
                 .country(creditBureau.getCountry())
+                .bureauType(creditBureau.getBureauType())
                 .registrationParamKeys(registrationParamKeys)
                 .build();
     }
@@ -46,6 +47,9 @@ public class CreditBureauMapper {
         creditBureau.setCreditBureauName(creditBureauData.getCreditBureauName());
         creditBureau.setActive(creditBureauData.isActive());
         creditBureau.setCountry(creditBureauData.getCountry());
+        creditBureau.setBureauType(creditBureauData.getBureauType() != null
+                ? creditBureauData.getBureauType()
+                : "CIRCULO_DE_CREDITO");
 
         // Registration Params handled in the service layer
 

--- a/src/main/java/org/mifos/creditbureau/service/connectors/CirculoDeCredito/CirculoDeCreditoConnector.java
+++ b/src/main/java/org/mifos/creditbureau/service/connectors/CirculoDeCredito/CirculoDeCreditoConnector.java
@@ -1,0 +1,182 @@
+package org.mifos.creditbureau.service.connectors.CirculoDeCredito;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.mifos.creditbureau.data.CBCreditReportData;
+import org.mifos.creditbureau.data.ClientData;
+import org.mifos.creditbureau.data.ConnectionTestResult;
+import org.mifos.creditbureau.data.CreditReportResult;
+import org.mifos.creditbureau.data.creditbureaus.CirculoDeCreditoRCCRequest;
+import org.mifos.creditbureau.data.creditbureaus.CirculoDeCreditoResponse;
+import org.mifos.creditbureau.mappers.CirculoDeCreditoResponseToCBCreditReportDataMapper;
+import org.mifos.creditbureau.mappers.ClientDatatoCirculoDeCreditoRccRequest;
+import org.mifos.creditbureau.service.connectors.CreditBureauConnector;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Circulo de Credito connector implementation.
+ * <p>
+ * Orchestrates existing services to fetch credit reports:
+ * <ol>
+ *   <li>Maps {@link ClientData} → {@link CirculoDeCreditoRCCRequest} (existing mapper)</li>
+ *   <li>Serializes to JSON and signs with ECDSA (existing {@link SignatureService})</li>
+ *   <li>POSTs to CDC production endpoint</li>
+ *   <li>Maps response → {@link CBCreditReportData} (existing response mapper)</li>
+ * </ol>
+ */
+@Service
+@Slf4j
+public class CirculoDeCreditoConnector implements CreditBureauConnector {
+
+    private static final String BUREAU_TYPE = "CIRCULO_DE_CREDITO";
+
+    private final SignatureService signatureService;
+    private final ClientDatatoCirculoDeCreditoRccRequest requestMapper;
+    private final CirculoDeCreditoResponseToCBCreditReportDataMapper responseMapper;
+    private final ObjectMapper objectMapper;
+    private final RestTemplate restTemplate;
+
+    @Value("${mifos.circulodecredito.base.url}")
+    private String baseUrl;
+
+    public CirculoDeCreditoConnector(
+            SignatureService signatureService,
+            ClientDatatoCirculoDeCreditoRccRequest requestMapper,
+            CirculoDeCreditoResponseToCBCreditReportDataMapper responseMapper,
+            ObjectMapper objectMapper) {
+        this.signatureService = signatureService;
+        this.requestMapper = requestMapper;
+        this.responseMapper = responseMapper;
+        this.objectMapper = objectMapper;
+        this.restTemplate = new RestTemplate();
+    }
+
+    CirculoDeCreditoConnector(
+            SignatureService signatureService,
+            ClientDatatoCirculoDeCreditoRccRequest requestMapper,
+            CirculoDeCreditoResponseToCBCreditReportDataMapper responseMapper,
+            ObjectMapper objectMapper,
+            RestTemplate restTemplate,
+            String baseUrl) {
+        this.signatureService = signatureService;
+        this.requestMapper = requestMapper;
+        this.responseMapper = responseMapper;
+        this.objectMapper = objectMapper;
+        this.restTemplate = restTemplate;
+        this.baseUrl = baseUrl;
+    }
+
+    @Override
+    public String getBureauType() {
+        return BUREAU_TYPE;
+    }
+
+    @Override
+    public CreditReportResult fetchCreditReport(Long creditBureauId, ClientData clientData) {
+        log.info("Fetching credit report from Circulo de Credito for bureau={}", creditBureauId);
+
+        try {
+            CirculoDeCreditoRCCRequest request = requestMapper
+                    .toCirculoDeCreditoRccRequest(clientData);
+
+            String requestBody = objectMapper.writeValueAsString(request);
+            log.debug("CDC request body: {}", requestBody);
+
+            Map<String, String> headersMap = signatureService
+                    .buildHeaders(creditBureauId, requestBody);
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headersMap.forEach(headers::set);
+
+            HttpEntity<String> entity = new HttpEntity<>(requestBody, headers);
+            String url = baseUrl + "v1/rcc";
+            log.info("Sending RCC request to {}", url);
+
+            ResponseEntity<String> response = restTemplate
+                    .exchange(url, HttpMethod.POST, entity, String.class);
+
+            CirculoDeCreditoResponse cdcResponse = objectMapper
+                    .readValue(response.getBody(), CirculoDeCreditoResponse.class);
+
+            CBCreditReportData report = responseMapper.toCBCreditReportData(cdcResponse);
+
+            log.info("Successfully fetched credit report from Circulo de Credito");
+            return CreditReportResult.builder()
+                    .success(true)
+                    .report(report)
+                    .bureauType(BUREAU_TYPE)
+                    .rawResponse(response.getBody())
+                    .fetchedAt(Instant.now())
+                    .build();
+
+        } catch (HttpClientErrorException e) {
+            log.error("CDC returned client error {}: {}", e.getStatusCode(), e.getMessage());
+            throw new RuntimeException(
+                    "Credit bureau rejected request (HTTP " + e.getStatusCode().value() + "): "
+                            + e.getResponseBodyAsString(), e);
+        } catch (HttpServerErrorException e) {
+            log.error("CDC returned server error {}: {}", e.getStatusCode(), e.getMessage());
+            throw new RuntimeException(
+                    "Credit bureau unavailable (HTTP " + e.getStatusCode().value() + "): "
+                            + e.getResponseBodyAsString(), e);
+        } catch (ResourceAccessException e) {
+            log.error("CDC connection failed: {}", e.getMessage());
+            throw new RuntimeException(
+                    "Unable to reach credit bureau: " + e.getMessage(), e);
+        } catch (Exception e) {
+            log.error("Unexpected error fetching credit report: {}", e.getMessage(), e);
+            throw new RuntimeException(
+                    "Failed to fetch credit report: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public ConnectionTestResult testConnection(Long creditBureauId) {
+        log.info("Testing connection to Circulo de Credito for bureau={}", creditBureauId);
+
+        try {
+            String testBody = "{\"attribute\":\"Hello World!\"}";
+
+            Map<String, String> headersMap = signatureService
+                    .buildHeaders(creditBureauId, testBody);
+            HttpHeaders headers = new HttpHeaders();
+            headersMap.forEach(headers::set);
+
+            HttpEntity<String> entity = new HttpEntity<>(testBody, headers);
+            String url = baseUrl + "v1/securitytest";
+
+            ResponseEntity<String> response = restTemplate
+                    .exchange(url, HttpMethod.POST, entity, String.class);
+
+            log.info("CDC security test returned status {}", response.getStatusCode());
+            return ConnectionTestResult.builder()
+                    .success(response.getStatusCode().is2xxSuccessful())
+                    .bureauType(BUREAU_TYPE)
+                    .message(response.getBody())
+                    .httpStatusCode(response.getStatusCode().value())
+                    .build();
+
+        } catch (Exception e) {
+            log.error("CDC connection test failed: {}", e.getMessage());
+            return ConnectionTestResult.builder()
+                    .success(false)
+                    .bureauType(BUREAU_TYPE)
+                    .message("Connection test failed: " + e.getMessage())
+                    .httpStatusCode(0)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/mifos/creditbureau/service/connectors/ConnectorRegistry.java
+++ b/src/main/java/org/mifos/creditbureau/service/connectors/ConnectorRegistry.java
@@ -1,0 +1,82 @@
+package org.mifos.creditbureau.service.connectors;
+
+import lombok.extern.slf4j.Slf4j;
+import org.mifos.creditbureau.domain.CreditBureau;
+import org.mifos.creditbureau.domain.CreditBureauRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Registry that auto-discovers all {@link CreditBureauConnector} beans
+ * via Spring dependency injection and resolves the correct connector
+ * at runtime based on the credit bureau's {@code bureauType}.
+ * <p>
+ * To register a new connector, simply create a {@code @Service} class
+ * implementing {@link CreditBureauConnector} — the registry picks it
+ * up automatically. No configuration, no switch statements.
+ */
+@Service
+@Slf4j
+public class ConnectorRegistry {
+
+    private final Map<String, CreditBureauConnector> connectors;
+    private final CreditBureauRepository creditBureauRepository;
+
+    /**
+     * Spring injects ALL {@link CreditBureauConnector} beans into
+     * the {@code connectorBeans} list. The registry indexes them
+     * by {@link CreditBureauConnector#getBureauType()}.
+     *
+     * @param connectorBeans all connector beans discovered by Spring
+     * @param creditBureauRepository repository to look up bureau entities
+     * @throws IllegalStateException if two connectors have the same bureau type
+     */
+    public ConnectorRegistry(List<CreditBureauConnector> connectorBeans,
+                             CreditBureauRepository creditBureauRepository) {
+        this.creditBureauRepository = creditBureauRepository;
+        this.connectors = connectorBeans.stream()
+                .collect(Collectors.toMap(
+                        CreditBureauConnector::getBureauType,
+                        Function.identity()));
+        log.info("Registered {} credit bureau connector(s): {}",
+                connectors.size(), connectors.keySet());
+    }
+
+    /**
+     * Resolve the correct connector for the given credit bureau ID.
+     *
+     * @param creditBureauId the database ID of the credit bureau
+     * @return the connector implementation for this bureau's type
+     * @throws IllegalArgumentException if the bureau ID is not found,
+     *         or if no connector is registered for the bureau's type
+     */
+    public CreditBureauConnector getConnector(Long creditBureauId) {
+        CreditBureau bureau = creditBureauRepository.findById(creditBureauId)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Credit Bureau not found with id: " + creditBureauId));
+
+        String type = bureau.getBureauType();
+        CreditBureauConnector connector = connectors.get(type);
+        if (connector == null) {
+            throw new IllegalArgumentException(
+                    "No connector registered for bureau type: " + type
+                            + ". Supported types: " + connectors.keySet());
+        }
+        return connector;
+    }
+
+    /**
+     * Returns all bureau types that have a registered connector.
+     *
+     * @return an unmodifiable set of supported bureau type keys
+     */
+    public Set<String> getSupportedTypes() {
+        return Collections.unmodifiableSet(connectors.keySet());
+    }
+}

--- a/src/main/java/org/mifos/creditbureau/service/connectors/CreditBureauConnector.java
+++ b/src/main/java/org/mifos/creditbureau/service/connectors/CreditBureauConnector.java
@@ -1,0 +1,46 @@
+package org.mifos.creditbureau.service.connectors;
+
+import org.mifos.creditbureau.data.ClientData;
+import org.mifos.creditbureau.data.ConnectionTestResult;
+import org.mifos.creditbureau.data.CreditReportResult;
+
+/**
+ * Strategy interface for credit bureau integrations.
+ * <p>
+ * Each supported credit bureau (e.g., Circulo de Credito, Equifax)
+ * provides an implementation of this interface. The {@link ConnectorRegistry}
+ * auto-discovers all implementations via Spring dependency injection
+ * and resolves the correct one at runtime based on
+ * {@link org.mifos.creditbureau.domain.CreditBureau#getBureauType()}.
+ * <p>
+ * To add support for a new credit bureau, simply create a new {@code @Service}
+ * class implementing this interface — no configuration or factory changes needed.
+ */
+public interface CreditBureauConnector {
+
+    /**
+     * Unique type key matching the {@code bureau_type} column in the
+     * {@code credit_bureau} table. Used by {@link ConnectorRegistry}
+     * for connector resolution.
+     *
+     * @return the bureau type identifier (e.g., "CIRCULO_DE_CREDITO")
+     */
+    String getBureauType();
+
+    /**
+     * Fetch a credit report from the external credit bureau for the given client.
+     *
+     * @param creditBureauId the ID of the registered credit bureau (used to retrieve API keys)
+     * @param clientData     the client data fetched from Fineract
+     * @return a {@link CreditReportResult} containing the generalized report and metadata
+     */
+    CreditReportResult fetchCreditReport(Long creditBureauId, ClientData clientData);
+
+    /**
+     * Verify connectivity and credential validity with the external credit bureau.
+     *
+     * @param creditBureauId the ID of the registered credit bureau
+     * @return a {@link ConnectionTestResult} indicating success or failure
+     */
+    ConnectionTestResult testConnection(Long creditBureauId);
+}

--- a/src/main/resources/db/changelog/02-add-bureau-type-column.xml
+++ b/src/main/resources/db/changelog/02-add-bureau-type-column.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+    <changeSet id="02-add-bureau-type" author="deathgun">
+        <comment>
+            Add bureau_type column to credit_bureau table for connector resolution.
+            Existing rows default to CIRCULO_DE_CREDITO.
+        </comment>
+        <addColumn tableName="credit_bureau">
+            <column name="bureau_type" type="VARCHAR(50)"
+                    defaultValue="CIRCULO_DE_CREDITO">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -7,5 +7,6 @@
 
     <!-- Include future changelog files here -->
      <include file="01-create-initial-schema.xml" relativeToChangelogFile="true"/>
-    
+     <include file="02-add-bureau-type-column.xml" relativeToChangelogFile="true"/>
+
 </databaseChangeLog>

--- a/src/test/java/org/mifos/creditbureau/service/connectors/CirculoDeCredito/CirculoDeCreditoConnectorTest.java
+++ b/src/test/java/org/mifos/creditbureau/service/connectors/CirculoDeCredito/CirculoDeCreditoConnectorTest.java
@@ -1,0 +1,175 @@
+package org.mifos.creditbureau.service.connectors.CirculoDeCredito;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mifos.creditbureau.data.CBCreditReportData;
+import org.mifos.creditbureau.data.ClientData;
+import org.mifos.creditbureau.data.ConnectionTestResult;
+import org.mifos.creditbureau.data.CreditReportResult;
+import org.mifos.creditbureau.data.creditbureaus.CirculoDeCreditoRCCRequest;
+import org.mifos.creditbureau.data.creditbureaus.CirculoDeCreditoResponse;
+import org.mifos.creditbureau.mappers.CirculoDeCreditoResponseToCBCreditReportDataMapper;
+import org.mifos.creditbureau.mappers.ClientDatatoCirculoDeCreditoRccRequest;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link CirculoDeCreditoConnector}.
+ * <p>
+ * This test class is in the same package as the connector to access
+ * package-private methods (e.g., {@link SignatureService#buildHeaders}).
+ */
+@ExtendWith(MockitoExtension.class)
+class CirculoDeCreditoConnectorTest {
+
+    @Mock private SignatureService signatureService;
+    @Mock private ClientDatatoCirculoDeCreditoRccRequest requestMapper;
+    @Mock private CirculoDeCreditoResponseToCBCreditReportDataMapper responseMapper;
+    @Mock private RestTemplate restTemplate;
+
+    private CirculoDeCreditoConnector connector;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        connector = new CirculoDeCreditoConnector(
+                signatureService, requestMapper, responseMapper,
+                objectMapper, restTemplate, "https://test.cdc.mx/");
+    }
+
+    @Test
+    @DisplayName("getBureauType returns CIRCULO_DE_CREDITO")
+    void getBureauType_returnsCIRCULO_DE_CREDITO() {
+        assertThat(connector.getBureauType()).isEqualTo("CIRCULO_DE_CREDITO");
+    }
+
+    @Test
+    @DisplayName("fetchCreditReport: happy path - calls mapper, signing, HTTP, response mapper in order")
+    void fetchCreditReport_happyPath_callsDependenciesInOrder() throws Exception {
+        // Arrange
+        ClientData clientData = ClientData.builder().build();
+        CirculoDeCreditoRCCRequest rccRequest = CirculoDeCreditoRCCRequest.builder().build();
+        CBCreditReportData reportData = CBCreditReportData.builder().build();
+
+        when(requestMapper.toCirculoDeCreditoRccRequest(clientData)).thenReturn(rccRequest);
+        when(signatureService.buildHeaders(eq(1L), anyString()))
+                .thenReturn(Map.of("Authorization", "Bearer test"));
+        when(restTemplate.exchange(
+                eq("https://test.cdc.mx/v1/rcc"),
+                eq(HttpMethod.POST),
+                any(HttpEntity.class),
+                eq(String.class)))
+                .thenReturn(new ResponseEntity<>("{}", HttpStatus.OK));
+        when(responseMapper.toCBCreditReportData(any(CirculoDeCreditoResponse.class)))
+                .thenReturn(reportData);
+
+        // Act
+        CreditReportResult result = connector.fetchCreditReport(1L, clientData);
+
+        // Assert
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getBureauType()).isEqualTo("CIRCULO_DE_CREDITO");
+        assertThat(result.getReport()).isEqualTo(reportData);
+        assertThat(result.getRawResponse()).isEqualTo("{}");
+        assertThat(result.getFetchedAt()).isNotNull();
+
+        // Verify call order: map → sign → HTTP → response map
+        InOrder order = inOrder(requestMapper, signatureService, restTemplate, responseMapper);
+        order.verify(requestMapper).toCirculoDeCreditoRccRequest(clientData);
+        order.verify(signatureService).buildHeaders(eq(1L), anyString());
+        order.verify(restTemplate).exchange(anyString(), eq(HttpMethod.POST),
+                any(HttpEntity.class), eq(String.class));
+        order.verify(responseMapper).toCBCreditReportData(any(CirculoDeCreditoResponse.class));
+    }
+
+    @Test
+    @DisplayName("fetchCreditReport: HTTP 500 from bureau throws RuntimeException")
+    void fetchCreditReport_httpServerError_throwsException() throws Exception {
+        ClientData clientData = ClientData.builder().build();
+        CirculoDeCreditoRCCRequest rccRequest = CirculoDeCreditoRCCRequest.builder().build();
+
+        when(requestMapper.toCirculoDeCreditoRccRequest(clientData)).thenReturn(rccRequest);
+        when(signatureService.buildHeaders(eq(1L), anyString()))
+                .thenReturn(Map.of("Authorization", "Bearer test"));
+        when(restTemplate.exchange(anyString(), eq(HttpMethod.POST),
+                any(HttpEntity.class), eq(String.class)))
+                .thenThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
+
+        assertThatThrownBy(() -> connector.fetchCreditReport(1L, clientData))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Credit bureau unavailable");
+    }
+
+    @Test
+    @DisplayName("fetchCreditReport: connection timeout throws RuntimeException")
+    void fetchCreditReport_timeout_throwsException() throws Exception {
+        ClientData clientData = ClientData.builder().build();
+        CirculoDeCreditoRCCRequest rccRequest = CirculoDeCreditoRCCRequest.builder().build();
+
+        when(requestMapper.toCirculoDeCreditoRccRequest(clientData)).thenReturn(rccRequest);
+        when(signatureService.buildHeaders(eq(1L), anyString()))
+                .thenReturn(Map.of("Authorization", "Bearer test"));
+        when(restTemplate.exchange(anyString(), eq(HttpMethod.POST),
+                any(HttpEntity.class), eq(String.class)))
+                .thenThrow(new ResourceAccessException("Connection timed out"));
+
+        assertThatThrownBy(() -> connector.fetchCreditReport(1L, clientData))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Unable to reach credit bureau");
+    }
+
+    @Test
+    @DisplayName("testConnection: success returns ConnectionTestResult with success=true")
+    void testConnection_success_returnsSuccessResult() throws Exception {
+        when(signatureService.buildHeaders(eq(1L), anyString()))
+                .thenReturn(Map.of("Authorization", "Bearer test"));
+        when(restTemplate.exchange(
+                eq("https://test.cdc.mx/v1/securitytest"),
+                eq(HttpMethod.POST),
+                any(HttpEntity.class),
+                eq(String.class)))
+                .thenReturn(new ResponseEntity<>("OK", HttpStatus.OK));
+
+        ConnectionTestResult result = connector.testConnection(1L);
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getBureauType()).isEqualTo("CIRCULO_DE_CREDITO");
+        assertThat(result.getMessage()).isEqualTo("OK");
+        assertThat(result.getHttpStatusCode()).isEqualTo(200);
+    }
+
+    @Test
+    @DisplayName("testConnection: failure returns result with success=false, not exception")
+    void testConnection_failure_returnsFailureResult() throws Exception {
+        when(signatureService.buildHeaders(eq(1L), anyString()))
+                .thenThrow(new RuntimeException("Key decryption failed"));
+
+        ConnectionTestResult result = connector.testConnection(1L);
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getBureauType()).isEqualTo("CIRCULO_DE_CREDITO");
+        assertThat(result.getMessage()).contains("Key decryption failed");
+        assertThat(result.getHttpStatusCode()).isEqualTo(0);
+    }
+}

--- a/src/test/java/org/mifos/creditbureau/service/connectors/ConnectorRegistryIntegrationTest.java
+++ b/src/test/java/org/mifos/creditbureau/service/connectors/ConnectorRegistryIntegrationTest.java
@@ -1,0 +1,148 @@
+package org.mifos.creditbureau.service.connectors;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mifos.creditbureau.data.ClientData;
+import org.mifos.creditbureau.data.ConnectionTestResult;
+import org.mifos.creditbureau.data.CreditReportResult;
+import org.mifos.creditbureau.domain.CreditBureau;
+import org.mifos.creditbureau.domain.CreditBureauRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Integration test for {@link ConnectorRegistry}.
+ * <p>
+ * Uses H2 + Liquibase (via {@code @DataJpaTest}) to verify that the
+ * registry correctly resolves connectors using real database lookups.
+ * A lightweight {@link StubConnector} is used instead of the full
+ * {@code CirculoDeCreditoConnector} to keep the test focused on
+ * registry wiring, not connector internals.
+ */
+@DataJpaTest
+@Import(ConnectorRegistryIntegrationTest.TestConfig.class)
+class ConnectorRegistryIntegrationTest {
+
+    @TestConfiguration
+    static class TestConfig {
+
+        @Bean
+        public CreditBureauConnector stubCDCConnector() {
+            return new StubConnector("CIRCULO_DE_CREDITO");
+        }
+
+        @Bean
+        public ConnectorRegistry connectorRegistry(
+                List<CreditBureauConnector> connectors,
+                CreditBureauRepository repo) {
+            return new ConnectorRegistry(connectors, repo);
+        }
+    }
+
+    @Autowired
+    private ConnectorRegistry registry;
+
+    @Autowired
+    private CreditBureauRepository creditBureauRepository;
+
+    @Test
+    @DisplayName("Spring context loads and registry contains CDC connector")
+    void contextLoads_registryContainsCDCConnector() {
+        assertThat(registry).isNotNull();
+        assertThat(registry.getSupportedTypes()).contains("CIRCULO_DE_CREDITO");
+    }
+
+    @Test
+    @DisplayName("getConnector: saved bureau with CDC type resolves correctly")
+    void getConnector_savedBureauWithCDCType_resolves() {
+        CreditBureau bureau = new CreditBureau();
+        bureau.setCreditBureauName("CDC Test");
+        bureau.setActive(true);
+        bureau.setCountry("Mexico");
+        bureau.setBureauType("CIRCULO_DE_CREDITO");
+        CreditBureau saved = creditBureauRepository.save(bureau);
+
+        CreditBureauConnector connector = registry.getConnector(saved.getId());
+
+        assertThat(connector).isNotNull();
+        assertThat(connector.getBureauType()).isEqualTo("CIRCULO_DE_CREDITO");
+    }
+
+    @Test
+    @DisplayName("getConnector: unknown ID throws IllegalArgumentException")
+    void getConnector_unknownId_throwsException() {
+        assertThatThrownBy(() -> registry.getConnector(999L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Credit Bureau not found");
+    }
+
+    @Test
+    @DisplayName("getSupportedTypes: contains CIRCULO_DE_CREDITO")
+    void supportedTypes_containsCIRCULO_DE_CREDITO() {
+        assertThat(registry.getSupportedTypes()).containsExactly("CIRCULO_DE_CREDITO");
+    }
+
+    @Test
+    @DisplayName("Registry resolves correctly with real H2 database lookup")
+    void registry_resolves_with_realDatabaseLookup() {
+        // Save two bureaus with different types
+        CreditBureau cdc = new CreditBureau();
+        cdc.setCreditBureauName("Circulo de Credito");
+        cdc.setActive(true);
+        cdc.setCountry("Mexico");
+        cdc.setBureauType("CIRCULO_DE_CREDITO");
+        CreditBureau savedCdc = creditBureauRepository.save(cdc);
+
+        // Unsupported type — registry should reject
+        CreditBureau unknown = new CreditBureau();
+        unknown.setCreditBureauName("Unknown Bureau");
+        unknown.setActive(true);
+        unknown.setCountry("US");
+        unknown.setBureauType("EQUIFAX");
+        CreditBureau savedUnknown = creditBureauRepository.save(unknown);
+
+        // CDC resolves
+        assertThat(registry.getConnector(savedCdc.getId()).getBureauType())
+                .isEqualTo("CIRCULO_DE_CREDITO");
+
+        // EQUIFAX has no registered connector → exception
+        assertThatThrownBy(() -> registry.getConnector(savedUnknown.getId()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("No connector registered for bureau type: EQUIFAX");
+    }
+
+    /**
+     * Lightweight stub connector for integration testing.
+     * Tests registry resolution, not connector behavior.
+     */
+    private static class StubConnector implements CreditBureauConnector {
+        private final String bureauType;
+
+        StubConnector(String bureauType) {
+            this.bureauType = bureauType;
+        }
+
+        @Override
+        public String getBureauType() {
+            return bureauType;
+        }
+
+        @Override
+        public CreditReportResult fetchCreditReport(Long creditBureauId, ClientData clientData) {
+            return CreditReportResult.builder().success(true).bureauType(bureauType).build();
+        }
+
+        @Override
+        public ConnectionTestResult testConnection(Long creditBureauId) {
+            return ConnectionTestResult.builder().success(true).bureauType(bureauType).build();
+        }
+    }
+}

--- a/src/test/java/org/mifos/creditbureau/service/connectors/ConnectorRegistryTest.java
+++ b/src/test/java/org/mifos/creditbureau/service/connectors/ConnectorRegistryTest.java
@@ -1,0 +1,148 @@
+package org.mifos.creditbureau.service.connectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mifos.creditbureau.data.ClientData;
+import org.mifos.creditbureau.data.ConnectionTestResult;
+import org.mifos.creditbureau.data.CreditReportResult;
+import org.mifos.creditbureau.domain.CreditBureau;
+import org.mifos.creditbureau.domain.CreditBureauRepository;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ConnectorRegistry}.
+ * Pure Mockito — no Spring context required.
+ */
+@ExtendWith(MockitoExtension.class)
+class ConnectorRegistryTest {
+
+    @Mock
+    private CreditBureauRepository creditBureauRepository;
+
+    private ConnectorRegistry registry;
+    private CreditBureauConnector cdcConnector;
+    private CreditBureauConnector equifaxConnector;
+
+    @BeforeEach
+    void setUp() {
+        cdcConnector = new StubConnector("CIRCULO_DE_CREDITO");
+        equifaxConnector = new StubConnector("EQUIFAX");
+    }
+
+    @Test
+    @DisplayName("getConnector: valid bureau ID resolves to correct connector")
+    void getConnector_withValidBureauId_returnsCorrectConnector() {
+        registry = new ConnectorRegistry(
+                List.of(cdcConnector, equifaxConnector), creditBureauRepository);
+
+        CreditBureau bureau = new CreditBureau();
+        bureau.setBureauType("CIRCULO_DE_CREDITO");
+        when(creditBureauRepository.findById(1L)).thenReturn(Optional.of(bureau));
+
+        CreditBureauConnector result = registry.getConnector(1L);
+
+        assertThat(result).isSameAs(cdcConnector);
+        assertThat(result.getBureauType()).isEqualTo("CIRCULO_DE_CREDITO");
+    }
+
+    @Test
+    @DisplayName("getConnector: unknown bureau ID throws IllegalArgumentException")
+    void getConnector_withUnknownBureauId_throwsException() {
+        registry = new ConnectorRegistry(
+                List.of(cdcConnector), creditBureauRepository);
+
+        when(creditBureauRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> registry.getConnector(999L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Credit Bureau not found with id: 999");
+    }
+
+    @Test
+    @DisplayName("getConnector: bureau exists but type has no registered connector")
+    void getConnector_withUnsupportedType_throwsException() {
+        registry = new ConnectorRegistry(
+                List.of(cdcConnector), creditBureauRepository);
+
+        CreditBureau bureau = new CreditBureau();
+        bureau.setBureauType("UNKNOWN_BUREAU");
+        when(creditBureauRepository.findById(1L)).thenReturn(Optional.of(bureau));
+
+        assertThatThrownBy(() -> registry.getConnector(1L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("No connector registered for bureau type: UNKNOWN_BUREAU");
+    }
+
+    @Test
+    @DisplayName("getSupportedTypes: returns all registered bureau types")
+    void getSupportedTypes_returnsAllRegistered() {
+        registry = new ConnectorRegistry(
+                List.of(cdcConnector, equifaxConnector), creditBureauRepository);
+
+        Set<String> types = registry.getSupportedTypes();
+
+        assertThat(types).containsExactlyInAnyOrder("CIRCULO_DE_CREDITO", "EQUIFAX");
+    }
+
+    @Test
+    @DisplayName("constructor: duplicate bureau types throws IllegalStateException")
+    void constructor_withDuplicateTypes_throwsException() {
+        CreditBureauConnector duplicate = new StubConnector("CIRCULO_DE_CREDITO");
+
+        assertThatThrownBy(() -> new ConnectorRegistry(
+                List.of(cdcConnector, duplicate), creditBureauRepository))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @DisplayName("constructor: empty connector list creates empty registry")
+    void constructor_withEmptyList_createsEmptyRegistry() {
+        registry = new ConnectorRegistry(List.of(), creditBureauRepository);
+
+        assertThat(registry.getSupportedTypes()).isEmpty();
+    }
+
+    /**
+     * Minimal stub connector for testing registry resolution logic.
+     * No external calls — just returns the bureau type.
+     */
+    private static class StubConnector implements CreditBureauConnector {
+        private final String bureauType;
+
+        StubConnector(String bureauType) {
+            this.bureauType = bureauType;
+        }
+
+        @Override
+        public String getBureauType() {
+            return bureauType;
+        }
+
+        @Override
+        public CreditReportResult fetchCreditReport(Long creditBureauId, ClientData clientData) {
+            return CreditReportResult.builder()
+                    .success(true)
+                    .bureauType(bureauType)
+                    .build();
+        }
+
+        @Override
+        public ConnectionTestResult testConnection(Long creditBureauId) {
+            return ConnectionTestResult.builder()
+                    .success(true)
+                    .bureauType(bureauType)
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
**Resolves MX-166**

### What this PR does

Introduces a Strategy-pattern connector architecture so the plugin can support multiple credit bureaus without modifying core logic.

**Core changes:**
- [CreditBureauConnector](cci:2://file:///home/deathgun/mifos-x-credit-bureau-plugin/src/main/java/org/mifos/creditbureau/service/connectors/CreditBureauConnector.java:18:0-45:1) — interface every bureau implements ([getBureauType()](cci:1://file:///home/deathgun/mifos-x-credit-bureau-plugin/src/test/java/org/mifos/creditbureau/service/connectors/ConnectorRegistryIntegrationTest.java:132:8-135:9), [fetchCreditReport()](cci:1://file:///home/deathgun/mifos-x-credit-bureau-plugin/src/test/java/org/mifos/creditbureau/service/connectors/ConnectorRegistryIntegrationTest.java:137:8-140:9), [testConnection()](cci:1://file:///home/deathgun/mifos-x-credit-bureau-plugin/src/main/java/org/mifos/creditbureau/service/connectors/CirculoDeCredito/CirculoDeCreditoConnector.java:152:4-188:5))
- [ConnectorRegistry](cci:2://file:///home/deathgun/mifos-x-credit-bureau-plugin/src/main/java/org/mifos/creditbureau/service/connectors/ConnectorRegistry.java:23:0-81:1) — Spring auto-discovers all connector beans via `List<CreditBureauConnector>` injection, resolves by `bureau_type` from DB
- [CirculoDeCreditoConnector](cci:2://file:///home/deathgun/mifos-x-credit-bureau-plugin/src/main/java/org/mifos/creditbureau/service/connectors/CirculoDeCredito/CirculoDeCreditoConnector.java:39:0-189:1) — refactors existing CDC logic (SignatureService, mappers) behind the interface
- [CreditReportApiResource](cci:2://file:///home/deathgun/mifos-x-credit-bureau-plugin/src/main/java/org/mifos/creditbureau/api/CreditReportApiResource.java:31:0-100:1) — generic `/credit-reports/{bureauId}/client/{clientId}` endpoint, bureau-agnostic
- Liquibase migration adding `bureau_type` column to `credit_bureau` table (`defaultValue="CIRCULO_DE_CREDITO"`)

**To add a new bureau:** create one `@Service` implementing [CreditBureauConnector](cci:2://file:///home/deathgun/mifos-x-credit-bureau-plugin/src/main/java/org/mifos/creditbureau/service/connectors/CreditBureauConnector.java:18:0-45:1). Zero config, zero factory changes.

### Testing
- [ConnectorRegistryTest](cci:2://file:///home/deathgun/mifos-x-credit-bureau-plugin/src/test/java/org/mifos/creditbureau/service/connectors/ConnectorRegistryTest.java:26:0-147:1) — 6 unit tests (resolution, error paths, duplicates, empty registry)
- [CirculoDeCreditoConnectorTest](cci:2://file:///home/deathgun/mifos-x-credit-bureau-plugin/src/test/java/org/mifos/creditbureau/service/connectors/CirculoDeCredito/CirculoDeCreditoConnectorTest.java:42:0-174:1) — 6 unit tests (happy path with InOrder verification, HTTP errors, timeouts)
- [ConnectorRegistryIntegrationTest](cci:2://file:///home/deathgun/mifos-x-credit-bureau-plugin/src/test/java/org/mifos/creditbureau/service/connectors/ConnectorRegistryIntegrationTest.java:29:0-147:1) — 5 integration tests (H2 + Liquibase, real DB lookups)
- All existing tests pass, zero regressions
