### PR TITLE
MX-273: Add POST /rcc/{clientId} endpoint, RFC extraction from /identifiers, fix static RestTemplate

### DIFF
--- a/src/main/java/org/mifos/creditbureau/api/CirculoDeCreditoApiResource.java
+++ b/src/main/java/org/mifos/creditbureau/api/CirculoDeCreditoApiResource.java
@@ -19,6 +19,28 @@ public class CirculoDeCreditoApiResource {
     @Autowired
     private ConsolidatedCreditReportService consolidatedCreditReportService;
 
+    /**
+     * POST /circulo-de-credito/rcc/{clientId}?creditBureauId={id}
+     *
+     * CB-ILD calls this endpoint for real CDC credit report pulls.
+     * Fetches Fineract client data, builds CDC request with ECDSA signing,
+     * calls CDC production endpoint, maps response.
+     *
+     * Phase 2 — replaces mock mode in CB-ILD CdcScorePullServiceImpl.
+     */
+    @POST
+    @Path("/rcc/{clientId}")
+    public Response callRCC(
+            @PathParam("clientId") Long clientId,
+            @jakarta.ws.rs.QueryParam("creditBureauId") Long creditBureauId)
+            throws Exception {
+        return Response.ok(
+                consolidatedCreditReportService
+                        .getConsolidatedCreditReport(
+                                creditBureauId, clientId))
+                .build();
+    }
+
     @POST
     @Path("/security-test/{creditBureauId}")
     public Response callSecurityTest(@PathParam("creditBureauId") Long creditBureauId) throws Exception{

--- a/src/main/java/org/mifos/creditbureau/data/ClientData.java
+++ b/src/main/java/org/mifos/creditbureau/data/ClientData.java
@@ -3,9 +3,17 @@ package org.mifos.creditbureau.data;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+
 import java.util.List;
 
-//TODO: what do do about dependents
+/**
+ * Aggregates client data from all Fineract endpoint calls.
+ *
+ * Phase 2 additions:
+ *   rfc — added from GET /clients/{id}/identifiers where
+ *         documentType=NATIONAL_ID. Falls back to externalId.
+ *         Required for CDC RCC request — CDC-001 without it.
+ */
 @Getter
 @Builder
 @AllArgsConstructor
@@ -13,12 +21,12 @@ public class ClientData {
     private final long id;
     private final String firstName;
     private final String lastName;
-    private final String externalId;
+    private final String externalId;      // fallback RFC source
+    private final String rfc;             // PRIMARY: from /identifiers NATIONAL_ID
     private final List<Integer> dateOfBirth;
     private final String nationality;
     private final String gender;
     private final String maritalStatus;
-
     private final String addressType;
     private final Long addressId;
     private final List<String> streetAddress;
@@ -27,8 +35,6 @@ public class ClientData {
     private final String country;
     private final String postalCode;
     private final String stateProvince;
-
     private final String phoneNumber;
     private final String emailAddress;
-
 }

--- a/src/main/java/org/mifos/creditbureau/data/client/FineractClientIdentifierResponse.java
+++ b/src/main/java/org/mifos/creditbureau/data/client/FineractClientIdentifierResponse.java
@@ -1,0 +1,36 @@
+package org.mifos.creditbureau.data.client;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * Maps GET /clients/{id}/identifiers response.
+ *
+ * documentType.value = "NATIONAL_ID" → documentKey = RFC
+ * RFC is CDC primary matching key — CDC-001 without it.
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FineractClientIdentifierResponse implements Serializable {
+
+    private DocumentType documentType;
+    private String documentKey;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DocumentType {
+        private String value;
+    }
+
+    public boolean isNationalId() {
+        return documentType != null
+                && "NATIONAL_ID".equals(documentType.getValue())
+                && documentKey != null
+                && !documentKey.isBlank();
+    }
+}

--- a/src/main/java/org/mifos/creditbureau/service/ClientApiService.java
+++ b/src/main/java/org/mifos/creditbureau/service/ClientApiService.java
@@ -1,24 +1,45 @@
 package org.mifos.creditbureau.service;
 
+import lombok.extern.slf4j.Slf4j;
 import org.mifos.creditbureau.data.ClientData;
 import org.mifos.creditbureau.data.client.FineractClientAddressResponse;
+import org.mifos.creditbureau.data.client.FineractClientIdentifierResponse;
 import org.mifos.creditbureau.data.client.FineractClientResponse;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-//TODO: implement null checks and error handling so that code will not break when api response is null.
-//TODO: implement a dynamic search, not just getting one client at a time? Do the search first, and then get the client if there is a match
+/**
+ * Fetches client data from Apache Fineract.
+ *
+ * Phase 2 fix: now calls all 3 endpoints:
+ *   GET /clients/{id}             → basic data
+ *   GET /clients/{id}/identifiers → RFC (NATIONAL_ID)
+ *   GET /clients/{id}/addresses   → address data
+ *
+ * RFC strategy:
+ *   Primary:  GET /identifiers where documentType=NATIONAL_ID
+ *   Fallback: externalId from GET /clients/{id}
+ *   If both null: rfc=null → CDC-001
+ *
+ * Security:
+ *   Never logs RFC value — only "RFC present: true/false"
+ */
+@Slf4j
 @Service
-public class ClientApiService{
+public class ClientApiService {
 
     @Value("${mifos.fineract.api.base-url.client}")
     private String fineractApiClientBaseUrl;
@@ -32,74 +53,173 @@ public class ClientApiService{
     @Value("${mifos.fineract.api.password}")
     private String password;
 
-    static RestTemplate restTemplate = new RestTemplate() ;
+    private final RestTemplate restTemplate;
 
-    public ClientData getClientData(Long clientId){
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization",getBasicAuthenticationHeader(username, password) );
-        headers.add("fineract-platform-tenantid", "default");
+    public ClientApiService(RestTemplateBuilder restTemplateBuilder) {
+        this.restTemplate = restTemplateBuilder
+                .setConnectTimeout(Duration.ofSeconds(10))
+                .setReadTimeout(Duration.ofSeconds(30))
+                .build();
+    }
 
-        HttpEntity<String> entity = new HttpEntity<>(headers);
+    private static final ParameterizedTypeReference<List<FineractClientIdentifierResponse>>
+            IDENTIFIER_LIST_TYPE = new ParameterizedTypeReference<>() {};
 
-        String clientUrl  = fineractApiClientBaseUrl + clientId;
-        ResponseEntity<FineractClientResponse> apiResponseEntity;
-        try {
-            apiResponseEntity = restTemplate.exchange(clientUrl, HttpMethod.GET, entity, FineractClientResponse.class);
-        } catch (Exception e) {
-            throw new IllegalStateException("Unable to fetch client from Fineract for clientId=" + clientId, e);
-        }
-        FineractClientResponse apiResponse = apiResponseEntity.getBody();
-        if (apiResponse == null) {
-            throw new IllegalStateException("Fineract returned an empty client payload for clientId=" + clientId);
-        }
+    public ClientData getClientData(Long clientId) {
+        HttpEntity<String> entity = new HttpEntity<>(buildHeaders());
 
-        String addressUrl = fineractApiClientAddressBaseUrl + clientId + "/addresses";
-        ResponseEntity<FineractClientAddressResponse[]> addressResponseEntity;
-        try {
-            addressResponseEntity = restTemplate.exchange(addressUrl, HttpMethod.GET, entity, FineractClientAddressResponse[].class);
-        } catch (Exception e) {
-            throw new IllegalStateException("Unable to fetch client addresses from Fineract for clientId=" + clientId, e);
-        }
-        FineractClientAddressResponse[] addressResponse = addressResponseEntity.getBody();
+        // Step 1 — basic client data
+        FineractClientResponse apiResponse =
+                fetchClientBasic(clientId, entity);
 
-        FineractClientAddressResponse firstAddressResponse = addressResponse != null && addressResponse.length > 0 //what if i need multiple addresses
-                ? addressResponse[0]
-                : null;
+        // Step 2 — RFC from identifiers
+        // Primary: NATIONAL_ID from /identifiers
+        // Fallback: externalId
+        String rfc = fetchRfc(clientId, entity,
+                apiResponse.getExternalId());
+        log.info("RFC present for clientId {}: {}",
+                clientId, rfc != null);
+
+        // Step 3 — address data
+        FineractClientAddressResponse firstAddress =
+                fetchAddress(clientId, entity);
 
         List<String> streetAddress = Stream.of(
-                        firstAddressResponse != null ? firstAddressResponse.getAddressLine1() : null,
-                        firstAddressResponse != null ? firstAddressResponse.getAddressLine2() : null,
-                        firstAddressResponse != null ? firstAddressResponse.getAddressLine3() : null
+                        firstAddress != null
+                                ? firstAddress.getAddressLine1() : null,
+                        firstAddress != null
+                                ? firstAddress.getAddressLine2() : null,
+                        firstAddress != null
+                                ? firstAddress.getAddressLine3() : null
                 )
                 .filter(s -> s != null && !s.isBlank())
                 .collect(Collectors.toList());
-
 
         return ClientData.builder()
                 .id(apiResponse.getId())
                 .firstName(apiResponse.getFirstname())
                 .lastName(apiResponse.getLastname())
                 .externalId(apiResponse.getExternalId())
+                .rfc(rfc)
                 .dateOfBirth(apiResponse.getDateOfBirth())
                 .phoneNumber(apiResponse.getMobileNo())
                 .emailAddress(apiResponse.getEmailAddress())
-                .nationality(firstAddressResponse != null ? firstAddressResponse.getCountryName() : null)
-
-                .addressType(firstAddressResponse != null ? firstAddressResponse.getAddressType() : null)
-                .addressId(firstAddressResponse != null ? firstAddressResponse.getId() : null)
+                .addressType(firstAddress != null
+                        ? firstAddress.getAddressType() : null)
+                .addressId(firstAddress != null
+                        ? firstAddress.getId() : null)
                 .streetAddress(streetAddress)
-                .townVillage(firstAddressResponse != null ? firstAddressResponse.getTownVillage() : null)
-                .city(firstAddressResponse != null ? firstAddressResponse.getCity() : null)
-                .stateProvince(firstAddressResponse != null ? firstAddressResponse.getStateName() : null)
-                .country(firstAddressResponse != null ? firstAddressResponse.getCountryName() : null)
-                .postalCode(firstAddressResponse != null ? firstAddressResponse.getPostalCode() : null)
-
+                .townVillage(firstAddress != null
+                        ? firstAddress.getTownVillage() : null)
+                .city(firstAddress != null
+                        ? firstAddress.getCity() : null)
+                .stateProvince(firstAddress != null
+                        ? firstAddress.getStateName() : null)
+                .country(firstAddress != null
+                        ? firstAddress.getCountryName() : null)
+                .postalCode(firstAddress != null
+                        ? firstAddress.getPostalCode() : null)
                 .build();
-
     }
-    private String getBasicAuthenticationHeader(String username, String password) {
+
+    private FineractClientResponse fetchClientBasic(
+            Long clientId, HttpEntity<String> entity) {
+        String url = fineractApiClientBaseUrl + clientId;
+        try {
+            ResponseEntity<FineractClientResponse> response =
+                    restTemplate.exchange(url, HttpMethod.GET,
+                            entity, FineractClientResponse.class);
+            if (response.getBody() == null) {
+                throw new IllegalStateException(
+                        "Fineract returned empty client for clientId="
+                                + clientId);
+            }
+            return response.getBody();
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                    "Unable to fetch client from Fineract for clientId="
+                            + clientId, e);
+        }
+    }
+
+    /**
+     * Fetch RFC from GET /clients/{id}/identifiers.
+     * Looks for documentType=NATIONAL_ID.
+     * Falls back to externalId if not found.
+     * Returns null if both missing.
+     * Never logs RFC value — only presence.
+     */
+    private String fetchRfc(Long clientId,
+            HttpEntity<String> entity, String externalId) {
+        String identifiersUrl = fineractApiClientBaseUrl
+                + clientId + "/identifiers";
+        try {
+            ResponseEntity<List<FineractClientIdentifierResponse>>
+                    response = restTemplate.exchange(
+                            identifiersUrl, HttpMethod.GET,
+                            entity, IDENTIFIER_LIST_TYPE);
+
+            if (response.getBody() != null) {
+                String rfc = response.getBody().stream()
+                        .filter(FineractClientIdentifierResponse
+                                ::isNationalId)
+                        .map(FineractClientIdentifierResponse
+                                ::getDocumentKey)
+                        .findFirst()
+                        .orElse(null);
+
+                if (rfc != null) return rfc;
+            }
+        } catch (HttpClientErrorException.NotFound e) {
+            log.debug("No identifiers found for clientId: {}",
+                    clientId);
+        } catch (Exception e) {
+            log.warn("Could not fetch identifiers for clientId: {} — {}",
+                    clientId, e.getMessage());
+        }
+
+        // Fallback to externalId
+        if (externalId != null && !externalId.isBlank()) {
+            log.debug("Using externalId as RFC fallback for clientId: {}",
+                    clientId);
+            return externalId;
+        }
+
+        return null;
+    }
+
+    private FineractClientAddressResponse fetchAddress(
+            Long clientId, HttpEntity<String> entity) {
+        String url = fineractApiClientAddressBaseUrl
+                + clientId + "/addresses";
+        try {
+            ResponseEntity<FineractClientAddressResponse[]> response =
+                    restTemplate.exchange(url, HttpMethod.GET,
+                            entity, FineractClientAddressResponse[].class);
+            FineractClientAddressResponse[] body = response.getBody();
+            return (body != null && body.length > 0) ? body[0] : null;
+        } catch (HttpClientErrorException.NotFound e) {
+            log.debug("No address found for clientId: {}", clientId);
+            return null;
+        } catch (Exception e) {
+            log.warn("Could not fetch address for clientId: {} — {}",
+                    clientId, e.getMessage());
+            return null;
+        }
+    }
+
+    private HttpHeaders buildHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization",
+                getBasicAuthenticationHeader(username, password));
+        headers.add("fineract-platform-tenantid", "default");
+        return headers;
+    }
+
+    private String getBasicAuthenticationHeader(
+            String username, String password) {
         String credentials = username + ":" + password;
-        return "Basic " + java.util.Base64.getEncoder().encodeToString(credentials.getBytes());
+        return "Basic " + java.util.Base64.getEncoder()
+                .encodeToString(credentials.getBytes());
     }
-
 }

--- a/src/main/java/org/mifos/creditbureau/service/connectors/CirculoDeCredito/ConsolidatedCreditReportService.java
+++ b/src/main/java/org/mifos/creditbureau/service/connectors/CirculoDeCredito/ConsolidatedCreditReportService.java
@@ -184,6 +184,7 @@ public class ConsolidatedCreditReportService {
                 .primerNombre(nvl(client.getFirstName()))
                 .apellidoPaterno(nvl(client.getLastName()))
                 .fechaNacimiento(formatDate(client.getDateOfBirth()))
+                .rfc(nvl(client.getRfc()))
                 // Address fields from Fineract
                 .domicilio(CirculoDeCreditoRCCRequest.Domicilio.builder()
                         .direccion(nvl(streetAddress))


### PR DESCRIPTION
## Summary
Phase 2 prep for CB-ILD integration. Fixes 4 issues that would cause CDC-001 on every real request.

## Changes

**1. FineractClientIdentifierResponse.java (NEW)**
Maps GET /clients/{id}/identifiers response.
isNationalId() checks documentType=NATIONAL_ID — same pattern as CB-ILD Phase 1.

**2. ClientData.java**
Added rfc field — populated from /identifiers NATIONAL_ID.
externalId kept as fallback.

**3. ClientApiService.java**
- Fixed static RestTemplate with no timeouts → RestTemplateBuilder 10s/30s
- Added fetchRfc() calling GET /clients/{id}/identifiers
- RFC never logged — only "RFC present: true/false"

**4. ConsolidatedCreditReportService.java**
Added .rfc(nvl(client.getRfc())) to buildRequest()
Without this CDC rejects every request with CDC-001.

**5. CirculoDeCreditoApiResource.java**
Added POST /circulo-de-credito/rcc/{clientId}?creditBureauId={id}
CB-ILD calls this endpoint in Phase 2 real mode.

## Testing
Compiles clean. Integration tests require MariaDB + CDC credentials.
Will test against mifos-bank-1 once Victor provides CDC developer account.

## Related
CB-ILD Phase 6: github.com/saksham869/cb-ild
Jira: MX-273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to retrieve consolidated credit reports for clients with their complete financial data from the credit bureau.

* **Improvements**
  * Enhanced client data collection to include phone numbers, email addresses, and national identification information with intelligent fallback mechanisms.
  * Improved error handling and logging for credit bureau API integration to better manage missing or invalid data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->